### PR TITLE
GHA-52 Disable GH issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: GitHub Automation
+    url: https://sonarsource.atlassian.net/browse/GHA
+    about: Jira Project for this repository


### PR DESCRIPTION
[GHA-52](https://sonarsource.atlassian.net/browse/GHA-52)

Similar to https://github.com/SonarSource/sonar-scanner-msbuild/blob/master/.github/ISSUE_TEMPLATE/config.yml

[GHA-52]: https://sonarsource.atlassian.net/browse/GHA-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ