### PR TITLE
GHA-70 ImportIssue: Fix docs

### DIFF
--- a/ImportIssue/ReadMe.md
+++ b/ImportIssue/ReadMe.md
@@ -26,7 +26,7 @@ None
 
 ## Prerequisites
 
-Ask DevInfra Squad to "Add Jira GitHub tokens" to the Vault configuration of your repository. Example: [PREQ-1272](https://sonarsource.atlassian.net/browse/PREQ-1272). This has additional need for `issues: write`, compared to the other actions.
+Ask DevInfra Squad to "Add Jira GitHub tokens" to the Vault configuration of your repository. Example: [PREQ-1272](https://sonarsource.atlassian.net/browse/PREQ-1272).
 
 ## Example usage
 


### PR DESCRIPTION
[GHA-70](https://sonarsource.atlassian.net/browse/GHA-70)

Undo part of #211, this action uses GITHUB_TOKEN from GH and not Vault.

[GHA-70]: https://sonarsource.atlassian.net/browse/GHA-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ