### PR TITLE
GHA-270 Update SlackNotification.yml runner to github-ubuntu-latest-s

### DIFF
--- a/.github/workflows/SlackNotification.yml
+++ b/.github/workflows/SlackNotification.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   checks: read
   id-token: write
+  actions: read
 
 jobs:
   slack-notifications:

--- a/.github/workflows/SlackNotification.yml
+++ b/.github/workflows/SlackNotification.yml
@@ -13,7 +13,7 @@ jobs:
   slack-notifications:
     if: >-
       contains(fromJSON('["main", "master"]'), github.event.check_suite.head_branch) || startsWith(github.event.check_suite.head_branch, 'dogfood-') || startsWith(github.event.check_suite.head_branch, 'branch-')
-    runs-on: sonar-runner
+    runs-on: github-ubuntu-latest-s
     steps:
       - name: Send Slack Notification
         env:


### PR DESCRIPTION
As documented [here](https://github.com/SonarSource/github-runners-infra/blob/master/docs/confluence-runner-docs/runners-quick-start.mmd) and the same runner is also used in the [scanner](https://github.com/SonarSource/sonar-scanner-msbuild/blob/19803eb6da97508256d1fb9577f4214b064a7dde/.github/workflows/SlackNotification.yml#L17).
