### PR TITLE
GHA-319 Migrate JS sub-actions to Node 24 runtime

### DIFF
--- a/ImportIssue/action.yml
+++ b/ImportIssue/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: 'Jira project key'
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/ImportIssue/Index.js'

--- a/LockBranch/action.yml
+++ b/LockBranch/action.yml
@@ -25,5 +25,5 @@ inputs:
     default: ''
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/LockBranch/Index.js'

--- a/LogPayload/action.yml
+++ b/LogPayload/action.yml
@@ -1,4 +1,4 @@
 name: 'Log event payload'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/LogPayload/Index.js'

--- a/PullRequestClosed/action.yml
+++ b/PullRequestClosed/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/PullRequestClosed/Index.js'

--- a/PullRequestCreated/action.yml
+++ b/PullRequestCreated/action.yml
@@ -27,5 +27,5 @@ inputs:
     description: 'Component added to team review PREQ ticket'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/PullRequestCreated/Index.js'

--- a/RequestReview/action.yml
+++ b/RequestReview/action.yml
@@ -18,5 +18,5 @@ inputs:
     description: 'Component added to team review PREQ ticket'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/RequestReview/Index.js'

--- a/SubmitReview/action.yml
+++ b/SubmitReview/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/SubmitReview/Index.js'

--- a/ToggleLockBranch/action.yml
+++ b/ToggleLockBranch/action.yml
@@ -22,5 +22,5 @@ inputs:
     default: ''
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/ToggleLockBranch/Index.js'


### PR DESCRIPTION
## Context

Drive-by from outside this repo: GitHub deprecated Node 20 on Actions runners on **2026-06-02** with full removal by Fall 2026. All 8 sub-actions here declare `using: 'node20'`:

- `ImportIssue`
- `LockBranch`
- `LogPayload`
- `PullRequestClosed`
- `PullRequestCreated`
- `RequestReview`
- `SubmitReview`
- `ToggleLockBranch`

These appear in several downstream workflows (Eng-XP repos pin `sonarsource/gh-action-lt-backlog/PullRequestClosed@v2` etc.), and will start emitting deprecation warnings now and breaking later this year.

## What changed

Flipped all 8 `using: 'node20'` → `using: 'node24'`. No source code or dist regeneration needed:
- `tsconfig.json` already targets `es2024`.
- `@types/node` is on `^25.6.0`.
- `@actions/core` v3, `@actions/github` v9, `@octokit/graphql` v9 — all on majors that ship Node 24 internals.

## Context for the lt-backlog team

Opening as a **draft** since I'm not a regular contributor here — leaving it for you to run CI, verify against your own dist build process, and merge on your own schedule. Happy to address any review feedback or hand it off.

Related upstream cascade: [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781). The Eng-XP-owned shared actions (`gh-action_cache`, `ci-github-actions`, `vault-action-wrapper`, etc.) have already shipped their Node 24 versions; the only Node 20 holdouts in our scans were these eight.


[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ