### PR TITLE
GHA-327 Test Node 24

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -3,10 +3,10 @@ name: Build
 on:
   schedule:
     - cron: "42 6 * * 1-5"
-  push:
-    branches:
-      - master
-  pull_request:
+  # push:
+  #   branches:
+  #     - master
+  # pull_request:
 
 jobs:
   validate-build:

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -21,7 +21,7 @@ jobs:
           secrets: |
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@master  # Use master to dogfood the DEV version. Use the latest @v branch in your repo.
+      - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@Pavel/TestNode24  # Use master to dogfood the DEV version. Use the latest @v branch in your repo.
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user:  ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -21,9 +21,15 @@ jobs:
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/PullRequestCreated@master  # Use master to dogfood the DEV version. Use the latest @v branch in your repo.
+      - uses: sonarsource/gh-action-lt-backlog/PullRequestCreated@Pavel/TestNode24  # Use master to dogfood the DEV version. Use the latest @v branch in your repo.
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
           jira-project: GHA
+
+  LogPayload_job:
+    name: Log payload
+    runs-on: github-ubuntu-latest-s
+    steps:
+      - uses: sonarsource/gh-action-lt-backlog/LogPayload@v2

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -21,8 +21,14 @@ jobs:
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/RequestReview@master  # Use master to dogfood the DEV version. Use the latest @v branch in your repo.
+      - uses: sonarsource/gh-action-lt-backlog/RequestReview@Pavel/TestNode24  # Use master to dogfood the DEV version. Use the latest @v branch in your repo.
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+
+  LogPayload_job:
+    name: Log payload
+    runs-on: github-ubuntu-latest-s
+    steps:
+      - uses: sonarsource/gh-action-lt-backlog/LogPayload@v2

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -23,8 +23,14 @@ jobs:
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/SubmitReview@master  # Use master to dogfood the DEV version. Use the latest @v branch in your repo.
+      - uses: sonarsource/gh-action-lt-backlog/SubmitReview@Pavel/TestNode24  # Use master to dogfood the DEV version. Use the latest @v branch in your repo.
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+
+  LogPayload_job:
+    name: Log payload
+    runs-on: github-ubuntu-latest-s
+    steps:
+      - uses: sonarsource/gh-action-lt-backlog/LogPayload@v2

--- a/ImportIssue/action.yml
+++ b/ImportIssue/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: 'Jira project key'
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/ImportIssue/Index.js'

--- a/LockBranch/action.yml
+++ b/LockBranch/action.yml
@@ -25,5 +25,5 @@ inputs:
     default: ''
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/LockBranch/Index.js'

--- a/LogPayload/action.yml
+++ b/LogPayload/action.yml
@@ -1,4 +1,4 @@
 name: 'Log event payload'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/LogPayload/Index.js'

--- a/PullRequestClosed/action.yml
+++ b/PullRequestClosed/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/PullRequestClosed/Index.js'

--- a/PullRequestCreated/action.yml
+++ b/PullRequestCreated/action.yml
@@ -24,5 +24,5 @@ inputs:
     description: 'Jira Team name to be used as a default fallback'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/PullRequestCreated/Index.js'

--- a/RequestReview/action.yml
+++ b/RequestReview/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/RequestReview/Index.js'

--- a/SubmitReview/action.yml
+++ b/SubmitReview/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/SubmitReview/Index.js'

--- a/ToggleLockBranch/action.yml
+++ b/ToggleLockBranch/action.yml
@@ -22,5 +22,5 @@ inputs:
     default: ''
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/ToggleLockBranch/Index.js'


### PR DESCRIPTION
Part of GHA-319
<!--
  Only for standalone PRs without Jira issue in the PR title:
    * Replace this comment with Epic ID to create a new Maintenance work item in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Maintenance work item in Jira without a parent
-->

----
## Summary by Gitar

- **Environment updates:**
  - Migrated all action definitions in `ImportIssue`, `LockBranch`, `LogPayload`, `PullRequestClosed`, `PullRequestCreated`, `RequestReview`, `SubmitReview`, and `ToggleLockBranch` to use `node24`.
- **Workflow adjustments:**
  - Updated local workflow references to point to the `Pavel/TestNode24` branch for testing purposes.
  - Added `LogPayload_job` to `PullRequestCreated.yml` and temporarily commented out `push` and `pull_request` triggers in `Build.yml`.

<sub>This will update automatically on new commits.</sub>