### PR TITLE
GHA-329 Add docs and parameter for rootly-token

### DIFF
--- a/PullRequestCreated/ReadMe.md
+++ b/PullRequestCreated/ReadMe.md
@@ -24,6 +24,12 @@ This action does nothing if the PR title contains `DO NOT MERGE` phrase.
 
 Token to access the GitHub API. This is a special token from Vault, see below. The default `secrets.GITHUB_TOKEN` does not have enough permissions.
 
+### `rootly-token`
+
+Optional token to access the Rootly API. This is needed only in repos that ask platform teams for reviews based on CODEOWNERS file.
+
+Vault token to use: `development/kv/data/rootly ro-api-key | ROOTLY_TOKEN;`
+
 ### `jira-user`
 
 User to access the Jira API.

--- a/PullRequestCreated/action.yml
+++ b/PullRequestCreated/action.yml
@@ -4,6 +4,9 @@ inputs:
   github-token:
     description: 'GitHub auth Token'
     required: true
+  rootly-token:
+    description: 'Rootly auth Token'
+    required: false
   jira-user:
     description: 'Jira auth user'
     required: true

--- a/RequestReview/ReadMe.md
+++ b/RequestReview/ReadMe.md
@@ -10,6 +10,12 @@ This action would typically move a ticket from `IN PROGRESS` to `IN REVIEW`. It 
 
 Token to access the GitHub API. This is a special token from Vault, see below. The default `secrets.GITHUB_TOKEN` does not have enough permissions.
 
+### `rootly-token`
+
+Optional token to access the Rootly API. This is needed only in repos that ask platform teams for reviews based on CODEOWNERS file.
+
+Vault token to use: `development/kv/data/rootly ro-api-key | ROOTLY_TOKEN;`
+
 ### `jira-user`
 
 User to access the Jira API.

--- a/RequestReview/action.yml
+++ b/RequestReview/action.yml
@@ -4,6 +4,9 @@ inputs:
   github-token:
     description: 'GitHub auth Token'
     required: true
+  rootly-token:
+    description: 'Rootly auth Token'
+    required: false
   jira-user:
     description: 'Jira auth User'
     required: true


### PR DESCRIPTION
Part of GHA-139

----
## Summary by Gitar

- **Action Configuration:**
  - Added `rootly-token` as an optional input parameter to both `PullRequestCreated` and `RequestReview` actions.
- **Documentation:**
  - Updated `ReadMe.md` files for both actions to include usage instructions and Vault secret paths for the `rootly-token` parameter.

<sub>This will update automatically on new commits.</sub>