### PR TITLE
CLP-21 Move repository ownership to Core Languages and Parsers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-.github/CODEOWNERS @SonarSource/quality-dotnet-squad
+.github/CODEOWNERS @SonarSource/code-quality-core-languages-parsers-squad
 
 # Force review from code owners on every file - required by GitHub Action Secure Configuration Policy
 # https://xtranet-sonarsource.atlassian.net/wiki/spaces/IS/pages/3990552676/GitHub+Action+Secure+Configuration+Policy
-* @SonarSource/quality-dotnet-squad
+* @SonarSource/code-quality-core-languages-parsers-squad


### PR DESCRIPTION
----
## Summary by Gitar

- **Ownership update:**
  - Update `CODEOWNERS` to assign repository ownership to the `code-quality-core-languages-parsers-squad` team.

<sub>This will update automatically on new commits.</sub>