### PR TITLE
GHA-375 Build: Use sonar-xs runner

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   validate-build:
     name: Validate Dist files
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Related to BUILD-10835 


----
## Summary by Gitar

- **Workflow configuration:**
  - Update `validate-build` job to use `sonar-xs` runner instead of `github-ubuntu-latest-s` in `.github/workflows/Build.yml`

<sub>This will update automatically on new commits.</sub>