### PR TITLE
GHA-387 ToggleLockBranch: Add sender name to the message

### DIFF
--- a/LockBranch/LockBranch.test.ts
+++ b/LockBranch/LockBranch.test.ts
@@ -24,6 +24,7 @@ import { LogTester } from '../tests/LogTester.js';
 import { createOctokitRestStub } from '../tests/OctokitRestStub.js';
 import { OctokitActionStub } from '../tests/OctokitActionStub.js';
 import { LockBranchActionStub } from '../tests/LockBranchActionStub.js';
+import * as github from '@actions/github';
 
 async function runAction(currentLockBranch: boolean): Promise<void> {
   const pattern = process.env['INPUT_BRANCH-PATTERN']!;
@@ -57,6 +58,13 @@ describe('LockBranch', () => {
     process.env['INPUT_BRANCH-PATTERN'] = 'master';
     process.env['INPUT_SLACK-CHANNEL'] = '';
     process.env['INPUT_ADDITIONAL-MESSAGE'] = '';
+    github.context.payload = {
+      sender: {
+        login: 'test-user',
+        type: "User",
+        html_url: "#test-url"
+      }
+    };
   });
 
   afterEach(() => {
@@ -69,7 +77,7 @@ describe('LockBranch', () => {
     expect(logTester.logsParams).toStrictEqual([
       "Invoked findRule(master)",
       "Invoked updateRule(rule-id, true)",
-      "Done: test-repo: The branch `master` was locked :ice_cube:",
+      "Done: *test-repo*: The branch `master` was locked :ice_cube: by <#test-url|test-user>",
       "Skip sending slack message, channel was not set.",
       "Done"
     ]);
@@ -82,7 +90,7 @@ describe('LockBranch', () => {
       "Invoked findRule(master)",
       "Invoked cancelAutoMerge(master)",
       "Invoked updateRule(rule-id, false)",
-      "Done: test-repo: The branch `master` was unlocked and is now open for changes :sunny:",
+      "Done: *test-repo*: The branch `master` was unlocked and is now open for changes :sunny: by <#test-url|test-user>",
       "Skip sending slack message, channel was not set.",
       "Done"
     ]);

--- a/ToggleLockBranch/ToggleLockBranch.test.ts
+++ b/ToggleLockBranch/ToggleLockBranch.test.ts
@@ -24,6 +24,7 @@ import { LogTester } from '../tests/LogTester.js';
 import { createOctokitRestStub } from '../tests/OctokitRestStub.js';
 import { OctokitActionStub } from '../tests/OctokitActionStub.js';
 import { LockBranchActionStub } from '../tests/LockBranchActionStub.js';
+import * as github from '@actions/github';
 
 async function runAction(currentLockBranch: boolean): Promise<void> {
   const pattern = process.env['INPUT_BRANCH-PATTERN']!;
@@ -57,6 +58,13 @@ describe('ToggleLockBranch', () => {
     process.env['INPUT_BRANCH-PATTERN'] = 'master';
     process.env['INPUT_SLACK-CHANNEL'] = '';
     process.env['INPUT_ADDITIONAL-MESSAGE'] = '';
+    github.context.payload = {
+      sender: {
+        login: 'test-user',
+        type: "User",
+        html_url: "#test-url"
+      }
+    };
   });
 
   afterEach(() => {
@@ -68,7 +76,7 @@ describe('ToggleLockBranch', () => {
     expect(logTester.logsParams).toStrictEqual([
       "Invoked findRule(master)",
       "Invoked updateRule(rule-id, true)",
-      "Done: test-repo: The branch `master` was locked :ice_cube:",
+      "Done: *test-repo*: The branch `master` was locked :ice_cube: by <#test-url|test-user>",
       "Skip sending slack message, channel was not set.",
       "Done"
     ]);
@@ -80,7 +88,7 @@ describe('ToggleLockBranch', () => {
       "Invoked findRule(master)",
       "Invoked cancelAutoMerge(master)",
       "Invoked updateRule(rule-id, false)",
-      "Done: test-repo: The branch `master` was unlocked and is now open for changes :sunny:",
+      "Done: *test-repo*: The branch `master` was unlocked and is now open for changes :sunny: by <#test-url|test-user>",
       "Skip sending slack message, channel was not set.",
       "Done"
     ]);

--- a/dist/LockBranch/LockBranch.test.js
+++ b/dist/LockBranch/LockBranch.test.js
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { LockBranch } from './LockBranch.js';
 import { LogTester } from '../tests/LogTester.js';
 import { createOctokitRestStub } from '../tests/OctokitRestStub.js';
+import * as github from '@actions/github';
 async function runAction(currentLockBranch) {
     const pattern = process.env['INPUT_BRANCH-PATTERN'];
     const action = new LockBranch();
@@ -51,6 +52,13 @@ describe('LockBranch', () => {
         process.env['INPUT_BRANCH-PATTERN'] = 'master';
         process.env['INPUT_SLACK-CHANNEL'] = '';
         process.env['INPUT_ADDITIONAL-MESSAGE'] = '';
+        github.context.payload = {
+            sender: {
+                login: 'test-user',
+                type: "User",
+                html_url: "#test-url"
+            }
+        };
     });
     afterEach(() => {
         logTester?.afterEach(); // When beforeAll fails, beforeEach is not called, but afterEach is.
@@ -61,7 +69,7 @@ describe('LockBranch', () => {
         expect(logTester.logsParams).toStrictEqual([
             "Invoked findRule(master)",
             "Invoked updateRule(rule-id, true)",
-            "Done: test-repo: The branch `master` was locked :ice_cube:",
+            "Done: *test-repo*: The branch `master` was locked :ice_cube: by <#test-url|test-user>",
             "Skip sending slack message, channel was not set.",
             "Done"
         ]);
@@ -73,7 +81,7 @@ describe('LockBranch', () => {
             "Invoked findRule(master)",
             "Invoked cancelAutoMerge(master)",
             "Invoked updateRule(rule-id, false)",
-            "Done: test-repo: The branch `master` was unlocked and is now open for changes :sunny:",
+            "Done: *test-repo*: The branch `master` was unlocked and is now open for changes :sunny: by <#test-url|test-user>",
             "Skip sending slack message, channel was not set.",
             "Done"
         ]);

--- a/dist/ToggleLockBranch/ToggleLockBranch.test.js
+++ b/dist/ToggleLockBranch/ToggleLockBranch.test.js
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ToggleLockBranch } from './ToggleLockBranch.js';
 import { LogTester } from '../tests/LogTester.js';
 import { createOctokitRestStub } from '../tests/OctokitRestStub.js';
+import * as github from '@actions/github';
 async function runAction(currentLockBranch) {
     const pattern = process.env['INPUT_BRANCH-PATTERN'];
     const action = new ToggleLockBranch();
@@ -51,6 +52,13 @@ describe('ToggleLockBranch', () => {
         process.env['INPUT_BRANCH-PATTERN'] = 'master';
         process.env['INPUT_SLACK-CHANNEL'] = '';
         process.env['INPUT_ADDITIONAL-MESSAGE'] = '';
+        github.context.payload = {
+            sender: {
+                login: 'test-user',
+                type: "User",
+                html_url: "#test-url"
+            }
+        };
     });
     afterEach(() => {
         logTester?.afterEach(); // When beforeAll fails, beforeEach is not called, but afterEach is.
@@ -60,7 +68,7 @@ describe('ToggleLockBranch', () => {
         expect(logTester.logsParams).toStrictEqual([
             "Invoked findRule(master)",
             "Invoked updateRule(rule-id, true)",
-            "Done: test-repo: The branch `master` was locked :ice_cube:",
+            "Done: *test-repo*: The branch `master` was locked :ice_cube: by <#test-url|test-user>",
             "Skip sending slack message, channel was not set.",
             "Done"
         ]);
@@ -71,7 +79,7 @@ describe('ToggleLockBranch', () => {
             "Invoked findRule(master)",
             "Invoked cancelAutoMerge(master)",
             "Invoked updateRule(rule-id, false)",
-            "Done: test-repo: The branch `master` was unlocked and is now open for changes :sunny:",
+            "Done: *test-repo*: The branch `master` was unlocked and is now open for changes :sunny: by <#test-url|test-user>",
             "Skip sending slack message, channel was not set.",
             "Done"
         ]);

--- a/dist/lib/LockBranchAction.js
+++ b/dist/lib/LockBranchAction.js
@@ -36,7 +36,7 @@ export class LockBranchAction extends OctokitAction {
                 if (updated.lockBranch === lockBranch) {
                     const action = lockBranch ? 'locked :ice_cube:' : 'unlocked and is now open for changes :sunny:';
                     const suffix = additionalMessage ? `\n\n${additionalMessage}` : '';
-                    const message = `${this.repo.repo}: The branch \`${pattern}\` was ${action}${suffix}`;
+                    const message = `*${this.repo.repo}*: The branch \`${pattern}\` was ${action} by <${this.payload.sender.html_url}|${this.payload.sender.login}>${suffix}`;
                     this.log(`Done: ${message}`);
                     this.sendSlackMessage(message);
                 }

--- a/dist/lib/LockBranchAction.test.js
+++ b/dist/lib/LockBranchAction.test.js
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { LockBranchAction } from './LockBranchAction.js';
 import { LogTester } from '../tests/LogTester.js';
 import { createOctokitRestStub } from '../tests/OctokitRestStub.js';
+import * as github from '@actions/github';
 class TestLockBranchAction extends LockBranchAction {
     lockValue;
     constructor(lockValue) {
@@ -215,6 +216,13 @@ describe('LockBranchAction', () => {
         process.env['INPUT_BRANCH-PATTERN'] = 'master';
         process.env['INPUT_SLACK-CHANNEL'] = '';
         process.env['INPUT_ADDITIONAL-MESSAGE'] = '';
+        github.context.payload = {
+            sender: {
+                login: 'test-user',
+                type: "User",
+                html_url: "#test-url"
+            }
+        };
     });
     afterEach(() => {
         logTester?.afterEach(); // When beforeAll fails, beforeEach is not called, but afterEach is.
@@ -234,7 +242,7 @@ describe('LockBranchAction', () => {
         expect(logTester.logsParams).toStrictEqual([
             "Invoked sendGraphQL list branch protection rules",
             "Invoked sendGraphQL updateBranchProtectionRule to lock id-of-unlocked-3",
-            "Done: test-repo: The branch `unlocked` was locked :ice_cube:",
+            "Done: *test-repo*: The branch `unlocked` was locked :ice_cube: by <#test-url|test-user>",
             "Skip sending slack message, channel was not set.",
             "Done"
         ]);
@@ -247,9 +255,9 @@ describe('LockBranchAction', () => {
         expect(logTester.logsParams).toStrictEqual([
             "Invoked sendGraphQL list branch protection rules",
             "Invoked sendGraphQL updateBranchProtectionRule to lock id-of-unlocked-3",
-            "Done: test-repo: The branch `unlocked` was locked :ice_cube:\n\nThis is because ABC",
+            "Done: *test-repo*: The branch `unlocked` was locked :ice_cube: by <#test-url|test-user>\n\nThis is because ABC",
             "Sending Slack message",
-            "Invoked sendSlackPost('https://slack.com/api/chat.postMessage', {\"channel\":\"channel-name\",\"text\":\"test-repo: The branch `unlocked` was locked :ice_cube:\\n\\nThis is because ABC\"}",
+            "Invoked sendSlackPost('https://slack.com/api/chat.postMessage', {\"channel\":\"channel-name\",\"text\":\"*test-repo*: The branch `unlocked` was locked :ice_cube: by <#test-url|test-user>\\n\\nThis is because ABC\"}",
             "Done"
         ]);
     });
@@ -279,9 +287,9 @@ describe('LockBranchAction', () => {
             "Invoked sendGraphQL disablePullRequestAutoMerge for pr-21",
             "Invoked rest.issues.createComment({\"owner\":\"test-owner\",\"repo\":\"test-repo\",\"issue_number\":21,\"body\":\"The target branch was unlocked and auto-merge was canceled to prevent unexpected actions.\"})",
             "Invoked sendGraphQL updateBranchProtectionRule to unlock id-of-locked-222",
-            "Done: test-repo: The branch `locked` was unlocked and is now open for changes :sunny:",
+            "Done: *test-repo*: The branch `locked` was unlocked and is now open for changes :sunny: by <#test-url|test-user>",
             "Sending Slack message",
-            "Invoked sendSlackPost('https://slack.com/api/chat.postMessage', {\"channel\":\"channel-name\",\"text\":\"test-repo: The branch `locked` was unlocked and is now open for changes :sunny:\"}",
+            "Invoked sendSlackPost('https://slack.com/api/chat.postMessage', {\"channel\":\"channel-name\",\"text\":\"*test-repo*: The branch `locked` was unlocked and is now open for changes :sunny: by <#test-url|test-user>\"}",
             "Done"
         ]);
     });

--- a/lib/LockBranchAction.test.ts
+++ b/lib/LockBranchAction.test.ts
@@ -23,6 +23,7 @@ import { LockBranchAction, ProtectionRule } from './LockBranchAction.js';
 import { LogTester } from '../tests/LogTester.js';
 import { createOctokitRestStub } from '../tests/OctokitRestStub.js';
 import { OctokitActionStub } from '../tests/OctokitActionStub.js';
+import * as github from '@actions/github';
 
 class TestLockBranchAction extends LockBranchAction {
   constructor(private readonly lockValue: boolean) {
@@ -219,6 +220,13 @@ describe('LockBranchAction', () => {
     process.env['INPUT_BRANCH-PATTERN'] = 'master';
     process.env['INPUT_SLACK-CHANNEL'] = '';
     process.env['INPUT_ADDITIONAL-MESSAGE'] = '';
+    github.context.payload = {
+      sender: {
+        login: 'test-user',
+        type: "User",
+        html_url: "#test-url"
+      }
+    };
   });
 
   afterEach(() => {
@@ -241,7 +249,7 @@ describe('LockBranchAction', () => {
     expect(logTester.logsParams).toStrictEqual([
       "Invoked sendGraphQL list branch protection rules",
       "Invoked sendGraphQL updateBranchProtectionRule to lock id-of-unlocked-3",
-      "Done: test-repo: The branch `unlocked` was locked :ice_cube:",
+      "Done: *test-repo*: The branch `unlocked` was locked :ice_cube: by <#test-url|test-user>",
       "Skip sending slack message, channel was not set.",
       "Done"
     ]);
@@ -255,9 +263,9 @@ describe('LockBranchAction', () => {
     expect(logTester.logsParams).toStrictEqual([
       "Invoked sendGraphQL list branch protection rules",
       "Invoked sendGraphQL updateBranchProtectionRule to lock id-of-unlocked-3",
-      "Done: test-repo: The branch `unlocked` was locked :ice_cube:\n\nThis is because ABC",
+      "Done: *test-repo*: The branch `unlocked` was locked :ice_cube: by <#test-url|test-user>\n\nThis is because ABC",
       "Sending Slack message",
-      "Invoked sendSlackPost('https://slack.com/api/chat.postMessage', {\"channel\":\"channel-name\",\"text\":\"test-repo: The branch `unlocked` was locked :ice_cube:\\n\\nThis is because ABC\"}",
+      "Invoked sendSlackPost('https://slack.com/api/chat.postMessage', {\"channel\":\"channel-name\",\"text\":\"*test-repo*: The branch `unlocked` was locked :ice_cube: by <#test-url|test-user>\\n\\nThis is because ABC\"}",
       "Done"
     ]);
   });
@@ -289,9 +297,9 @@ describe('LockBranchAction', () => {
       "Invoked sendGraphQL disablePullRequestAutoMerge for pr-21",
       "Invoked rest.issues.createComment({\"owner\":\"test-owner\",\"repo\":\"test-repo\",\"issue_number\":21,\"body\":\"The target branch was unlocked and auto-merge was canceled to prevent unexpected actions.\"})",
       "Invoked sendGraphQL updateBranchProtectionRule to unlock id-of-locked-222",
-      "Done: test-repo: The branch `locked` was unlocked and is now open for changes :sunny:",
+      "Done: *test-repo*: The branch `locked` was unlocked and is now open for changes :sunny: by <#test-url|test-user>",
       "Sending Slack message",
-      "Invoked sendSlackPost('https://slack.com/api/chat.postMessage', {\"channel\":\"channel-name\",\"text\":\"test-repo: The branch `locked` was unlocked and is now open for changes :sunny:\"}",
+      "Invoked sendSlackPost('https://slack.com/api/chat.postMessage', {\"channel\":\"channel-name\",\"text\":\"*test-repo*: The branch `locked` was unlocked and is now open for changes :sunny: by <#test-url|test-user>\"}",
       "Done"
     ]);
   });

--- a/lib/LockBranchAction.ts
+++ b/lib/LockBranchAction.ts
@@ -52,7 +52,7 @@ export abstract class LockBranchAction extends OctokitAction {
         if (updated.lockBranch === lockBranch) {
           const action = lockBranch ? 'locked :ice_cube:' : 'unlocked and is now open for changes :sunny:';
           const suffix = additionalMessage ? `\n\n${additionalMessage}` : '';
-          const message = `${this.repo.repo}: The branch \`${pattern}\` was ${action}${suffix}`;
+          const message = `*${this.repo.repo}*: The branch \`${pattern}\` was ${action} by <${this.payload.sender!.html_url}|${this.payload.sender!.login}>${suffix}`;
           this.log(`Done: ${message}`);
           this.sendSlackMessage(message);
         } else {


### PR DESCRIPTION
Part of 
<!--
  Only for standalone PRs without Jira issue in the PR title:
    * Replace this comment with Epic ID to create a new Maintenance work item in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Maintenance work item in Jira without a parent
-->

----
## Summary by Gitar

- **Slack notifications:**
    - Included the sender's name and profile link in branch lock and unlock messages


<sub>This will update automatically on new commits.</sub>